### PR TITLE
Add initial `IPAddress` library code.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright DATE COPYRIGHT_HOLDER
+Copyright 2022 Joe Eli McIlvain
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-A base repository for Savi language libraries, with common CI actions configured.
+# IPAddress
 
-See the [Guide](https://github.com/savi-lang/base-standard-library/wiki/Guide) for details on how it works and how to use it for your own libraries.
+A Savi standard library for IPv4 and IPv6 address parsing, printing, and manipulation.

--- a/manifest.savi
+++ b/manifest.savi
@@ -1,0 +1,22 @@
+:manifest lib IPAddress
+  :sources "src/*.savi"
+
+:manifest bin "spec"
+  :copies IPAddress
+  :sources "spec/*.savi"
+
+  :dependency Spec v0
+    :from "github:savi-lang/Spec"
+    :depends on Map
+    :depends on Time
+    :depends on Timer
+
+  :transitive dependency Map v0
+    :from "github:savi-lang/Map"
+
+  :transitive dependency Time v0
+    :from "github:savi-lang/Time"
+
+  :transitive dependency Timer v0
+    :from "github:savi-lang/Timer"
+    :depends on Time

--- a/spec/IPAddress.Spec.savi
+++ b/spec/IPAddress.Spec.savi
@@ -1,0 +1,22 @@
+:class IPAddress.Spec
+  :is Spec
+  :const describes: "IPAddress"
+
+  :it "creates an IPv4 address from a raw U32 value"
+    assert: "\(IPAddress.new_raw_v4(0x00_00_00_00))" == "0.0.0.0"
+    assert: "\(IPAddress.new_raw_v4(0xFF_FF_FF_FF))" == "255.255.255.255"
+    assert: "\(IPAddress.new_raw_v4(0x01_23_45_67))" == "1.35.69.103"
+    assert: "\(IPAddress.new_raw_v4(0xFE_DC_BA_98))" == "254.220.186.152"
+
+  :it "creates an IPv6 address from two raw U64 values"
+    assert: "\(IPAddress.new_raw_v6(0, 0))" == "::"
+    assert: "\(IPAddress.new_raw_v6(0, 1))" == "::1"
+    assert: "\(IPAddress.new_raw_v6(0xFF02_0000_0000_0000, 0))" == "ff02::"
+    assert: "\(IPAddress.new_raw_v6(0xFF02_0000_0000_0000, 1))" == "ff02::1"
+    assert: "\(IPAddress.new_raw_v6(0xFF02_03EE_0000_0000, 0))" == "ff02:3ee::"
+    assert: "\(IPAddress.new_raw_v6(0xFF02_03EE_0000_0000, 1))" == "ff02:3ee::1"
+    assert: "\(IPAddress.new_raw_v6(0xB, 0x2))" == "::b:0:0:0:2"
+    assert: (
+      "\(IPAddress.new_raw_v6(0x0123_4567_89AB_CDEF, 0xFEDC_BA98_7654_3210))"
+      == "123:4567:89ab:cdef:fedc:ba98:7654:3210"
+    )

--- a/spec/Main.savi
+++ b/spec/Main.savi
@@ -1,0 +1,5 @@
+:actor Main
+  :new (env Env)
+    Spec.Process.run(env, [
+      Spec.Run(IPAddress.Spec).new(env)
+    ])

--- a/src/IPAddress.Format.savi
+++ b/src/IPAddress.Format.savi
@@ -1,0 +1,59 @@
+:struct IPAddress.Format
+  :is IntoString
+
+  :let _value IPAddress'box
+  :new (@_value)
+
+  :fun into_string_space USize:
+    if @_value.is_v4 (
+      "xxx.xxx.xxx.xxx".size
+    |
+      "xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx".size
+    )
+
+  :fun into_string(out String'iso) String'iso
+    at_start = True
+    if @_value.is_v4 (
+      @_value._v4_each_u8 -> (u8 |
+        if !at_start out.push_byte('.')
+        at_start = False
+        out = u8.into_string(--out)
+      )
+    |
+      previous_deferred_zero = False
+      is_compressing_zeros = False
+      did_compress_zeros = False
+      @_value._v6_each_u16 -> (u16 |
+        if (u16 == 0 && !did_compress_zeros) (
+          case (
+          | is_compressing_zeros | next // go straight to the next u16
+          | previous_deferred_zero |
+            out << "::"
+            at_start = True
+            previous_deferred_zero = False
+            is_compressing_zeros = True
+            next
+          |
+            previous_deferred_zero = True
+            next
+          )
+        |
+          case (
+          | is_compressing_zeros |
+            is_compressing_zeros = False
+            did_compress_zeros = True
+          | previous_deferred_zero |
+            if !at_start out.push_byte(':')
+            at_start = False
+            out.push_byte('0')
+            previous_deferred_zero = False
+          )
+        )
+        if !at_start out.push_byte(':')
+        at_start = False
+        out = u16
+          .format.hex.bare.lowercase.without_leading_zeros
+          .into_string(--out)
+      )
+    )
+    --out

--- a/src/IPAddress.savi
+++ b/src/IPAddress.savi
@@ -1,0 +1,49 @@
+:struct IPAddress
+  :let _raw_v6_hi U64
+  :let _raw_v6_lo U64
+
+  // This field indicates whether the address is IPv4 or IPv6, and also
+  // indicates the number of leading significant bits (i.e. a CIDR mask).
+  //
+  // For IPv6, this is in the 0 to -128 range, indicating 0 to 128 CIDR bits.
+  :let _bits I8
+
+  :fun is_v6: @_bits <= 0
+  :fun is_v4: @_bits > 0
+
+  :fun _v6_cidr_bits U8: if (@_bits == -128) (128 | @_bits.negate.u8)
+  :fun _v4_cidr_bits U8: @_bits.u8.bit_shr(8).bit_and(0x3F)
+
+  // For IPv4, the raw bytes are kept in the low 32 bits of the IPv6 raw bytes.
+  // Here we define a getter and setter function to let us access them easily.
+  :fun _raw_v4: @_raw_v6_lo.u32
+
+  :new val new_raw_v4(raw_v4 U32): @_raw_v6_hi = 0, @_raw_v6_lo = raw_v4.u64, @_bits = 96
+  :new val new_raw_v6(@_raw_v6_hi, @_raw_v6_lo): @_bits = -128
+
+  :fun _v4_each_u8
+    raw = @_raw_v4
+    yield raw.bit_shr(24).u8
+    yield raw.bit_shr(16).u8
+    yield raw.bit_shr(8).u8
+    yield raw.u8
+    @
+
+  :fun _v6_each_u16
+    raw_hi = @_raw_v6_hi
+    raw_lo = @_raw_v6_lo
+    yield raw_hi.bit_shr(48).u16
+    yield raw_hi.bit_shr(32).u16
+    yield raw_hi.bit_shr(16).u16
+    yield raw_hi.u16
+    yield raw_lo.bit_shr(48).u16
+    yield raw_lo.bit_shr(32).u16
+    yield raw_lo.bit_shr(16).u16
+    yield raw_lo.u16
+    @
+
+  :fun format: IPAddress.Format.new(@)
+
+  :is IntoString
+  :fun into_string(out String'iso): @format.into_string(--out)
+  :fun into_string_space: @format.into_string_space


### PR DESCRIPTION
This is the initial implementation of the `IPAddress` library.

So far we have the ability to construct `IPAddress` instances for IPv4 and IPv6 from raw number values, and to print them to strings in the expected format.