### PR TITLE
Add `IPAddress.WithPortNumber` struct.

### DIFF
--- a/spec/IPAddress.WithPortNumber.Spec.savi
+++ b/spec/IPAddress.WithPortNumber.Spec.savi
@@ -1,0 +1,7 @@
+:class IPAddress.WithPortNumber.Spec
+  :is Spec
+  :const describes: "IPAddress.WithPortNumber"
+
+  :it "associates a port number to an IP address"
+    assert: "\(IPAddress.v4_zero.with_port_number(8080))" == "0.0.0.0:8080"
+    assert: "\(IPAddress.v6_zero.with_port_number(0xFFFF))" == "[::]:65535"

--- a/spec/Main.savi
+++ b/spec/Main.savi
@@ -2,4 +2,5 @@
   :new (env Env)
     Spec.Process.run(env, [
       Spec.Run(IPAddress.Spec).new(env)
+      Spec.Run(IPAddress.WithPortNumber.Spec).new(env)
     ])

--- a/src/IPAddress.WithPortNumber.savi
+++ b/src/IPAddress.WithPortNumber.savi
@@ -1,0 +1,25 @@
+:struct val IPAddress.WithPortNumber
+  :let address IPAddress
+  :let port_number U16
+  :new val (@address, @port_number)
+
+  :is IntoString
+  :fun into_string_space:
+    if @address.is_v4 (
+      @address.into_string_space + 1 + @port_number.into_string_space
+    |
+      @address.into_string_space + 3 + @port_number.into_string_space
+    )
+  :fun into_string(out String'iso)
+    if @address.is_v4 (
+      out = @address.into_string(--out)
+      out.push_byte(':')
+      out = @port_number.into_string(--out)
+    |
+      out.push_byte('[')
+      out = @address.into_string(--out)
+      out.push_byte(']')
+      out.push_byte(':')
+      out = @port_number.into_string(--out)
+    )
+    --out

--- a/src/IPAddress.savi
+++ b/src/IPAddress.savi
@@ -1,4 +1,4 @@
-:struct IPAddress
+:struct val IPAddress
   :let _v6_raw_hi U64
   :let _v6_raw_lo U64
 
@@ -20,6 +20,12 @@
 
   :new val new_v4_raw(v4_raw U32): @_v6_raw_hi = 0, @_v6_raw_lo = v4_raw.u64, @_bits = 96
   :new val new_v6_raw(@_v6_raw_hi, @_v6_raw_lo): @_bits = -128
+
+  :fun non v4_zero: @new_v4_raw(0)
+  :fun non v6_zero: @new_v6_raw(0, 0)
+
+  :fun val with_port_number(port_number)
+    IPAddress.WithPortNumber.new(@, port_number)
 
   :fun _v4_each_u8
     raw = @_v4_raw


### PR DESCRIPTION
This allows conveniently storing and printing an IP address along with a port number.

Motivation: The `TCP` library will use this to expose the local and remote address/port pairs associated with a TCP connection.